### PR TITLE
Build accession_analysis on Ubuntu 16

### DIFF
--- a/dnanexus/accession_analysis/dxapp.json
+++ b/dnanexus/accession_analysis/dxapp.json
@@ -120,6 +120,7 @@
   "runSpec": {
     "interpreter": "python2.7",
     "file": "src/accession_analysis.py",
+    "distribution": "Ubuntu", "release": "16.04",
     "execDepends": [
     ],
     "assetDepends": [


### PR DESCRIPTION
This fixes the SSL certificate selection problem when accessioning to test.